### PR TITLE
Handle integer header keys

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -211,7 +211,11 @@ abstract class ServerRequestFactory
 
             if ($value && strpos($key, 'HTTP_') === 0) {
                 $name = strtr(strtolower(substr($key, 5)), '_', '-');
-                $headers[$name] = $value;
+
+                if (! is_numeric($name)) {
+                  $headers[$name] = $value;
+                }
+
                 continue;
             }
 

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -62,6 +62,7 @@ class ServerRequestFactoryTest extends TestCase
             'HTTP_CONTENT_TYPE' => 'application/json',
             'HTTP_ACCEPT' => 'application/json',
             'HTTP_X_FOO_BAR' => 'FOOBAR',
+            'HTTP__1' => '-1',
             'CONTENT_MD5' => 'CONTENT-MD5',
             'CONTENT_LENGTH' => 'UNSPECIFIED',
         ];


### PR DESCRIPTION
Here, at getpocket.com, we have had a client hit our servers with
header keys as integers. In doing so `HeaderSecurity::assertValidName`
is throwing an exception because `! is_string(-1) === true`.

I have been unable to identify any documentation which would suggest
that these values could be valid. At this point I believe the best
behavior is to ignore these keys.